### PR TITLE
Add handleUriChange to History Routing Scaffold

### DIFF
--- a/historyRoutingBased/index.js
+++ b/historyRoutingBased/index.js
@@ -2,7 +2,7 @@ import { AppContainer } from 'react-hot-loader';
 import { Provider }     from 'react-redux';
 import { render }       from 'react-dom';
 import App              from 'historyRoutingBased/components/App';
-import historyInstance  from 'historyRoutingBased/lib/historyInstance;
+import historyInstance  from 'historyRoutingBased/lib/historyInstance';
 import React            from 'react';
 import store            from './store';
 

--- a/historyRoutingBased/index.js
+++ b/historyRoutingBased/index.js
@@ -2,10 +2,13 @@ import { AppContainer } from 'react-hot-loader';
 import { Provider }     from 'react-redux';
 import { render }       from 'react-dom';
 import App              from 'historyRoutingBased/components/App';
+import historyInstance  from 'historyRoutingBased/lib/historyInstance;
 import React            from 'react';
 import store            from './store';
 
 module.exports = (targetEl) => {
+  historyInstance.handleUriChange();
+
   const renderApp = AppComponent => {
     render(
       <Provider store={ store }>


### PR DESCRIPTION
#### *Description*

I added `handleUriChange` to be called in the initialization of the app. It's not ideally where I would put it (I'd prefer `componentWillMount` in the App component). But this is where it's being called throughout almost every app that uses History Interface.

What's important is that it _is_ called and that it's a part of the scaffold _somewhere_.

#### Screenshots
![screen shot 2018-10-25 at 4 01 33 pm](https://user-images.githubusercontent.com/9851764/47533010-4d05df00-d86f-11e8-8b8d-0efa78684efc.png)
